### PR TITLE
Only runs the banner.js when 'window' is available

### DIFF
--- a/packages/esbuild-plugin-livereload/banner.js
+++ b/packages/esbuild-plugin-livereload/banner.js
@@ -1,4 +1,5 @@
 (() => {
+  if (typeof window === 'undefined') return;
   if (window.__ESBUILD_LR_PLUGIN__) return;
   window.__ESBUILD_LR_PLUGIN__ = '{baseUrl}';
   const script = document.createElement('script');


### PR DESCRIPTION
The plugin is awesome, but its breaking my service workers bundles by trying to access properties from 'window' (which isn't available in service workers context). To fix it I just test if window is available before running banner.js script.