### PR TITLE
@jgoz/esbuild-plugin-livereload parameter to accept external connections

### DIFF
--- a/packages/esbuild-plugin-livereload/src/livereload-plugin.ts
+++ b/packages/esbuild-plugin-livereload/src/livereload-plugin.ts
@@ -62,6 +62,13 @@ export interface LivereloadPluginOptions {
    * @default 127.0.0.1
    */
   host?: string;
+
+  /**
+   * Override server to allow connection from any IP
+   *
+   * @default false
+   */
+  allowExternalConnections?: false;
 }
 
 /**
@@ -72,7 +79,7 @@ export interface LivereloadPluginOptions {
  * @returns - An esbuild plugin that enables livereload.
  */
 export function livereloadPlugin(options: LivereloadPluginOptions = {}): Plugin {
-  const { port = 53099, host = '127.0.0.1' } = options;
+  const { port = 53099, host = '127.0.0.1', allowExternalConnections = false } = options;
   const baseUrl = `http://${host}:${port}/`;
 
   return {
@@ -82,7 +89,7 @@ export function livereloadPlugin(options: LivereloadPluginOptions = {}): Plugin 
       const bannerTemplate = await fsp.readFile(require.resolve('../banner.js'), 'utf-8');
       const banner = bannerTemplate.replace(/{baseUrl}/g, baseUrl);
 
-      await createLivereloadServer({ basedir, host, port, onSSE: res => clients.add(res) });
+      await createLivereloadServer({ basedir, host, port, allowExternalConnections, onSSE: res => clients.add(res) });
 
       build.initialOptions.banner ??= {};
       if (build.initialOptions.banner.js) {

--- a/packages/esbuild-plugin-livereload/src/server.ts
+++ b/packages/esbuild-plugin-livereload/src/server.ts
@@ -10,6 +10,7 @@ export interface LivereloadServerOptions {
   basedir: string;
   port: number;
   host: string;
+  allowExternalConnections: boolean;
   onSSE: (res: ServerResponse) => void;
 }
 
@@ -84,5 +85,8 @@ export async function createLivereloadRequestHandler(
  */
 export async function createLivereloadServer(options: LivereloadServerOptions): Promise<Server> {
   const handler = await createLivereloadRequestHandler(options);
-  return createServer(handler).listen(options.port, options.host);
+  const host = options.allowExternalConnections
+    ? '0.0.0.0'
+    : options.host;
+  return createServer(handler).listen(options.port, host);
 }


### PR DESCRIPTION
Attempt at fixing issue #114.

I was uncertain how to go about testing the changes, however, I did verify that setting `host` to `0.0.0.0` in `packages/esbuild-plugin-livereload/src/server.ts` does fix the issue for me.

This PR adds an option that sets the server `host` to `0.0.0.0`, while preserving the `host` value that determines where the script is fetched from.